### PR TITLE
Allow users set dhcp mtu by l3 network

### DIFF
--- a/src/zvr/plugin/dhcp.go
+++ b/src/zvr/plugin/dhcp.go
@@ -22,6 +22,7 @@ type dhcpInfo struct {
 	VrNicMac string `json:"vrNicMac"`
 	DnsDomain string `json:"dnsDomain"`
 	IsDefaultL3Network bool `json:"isDefaultL3Network"`
+	Mtu int `json:"mtu"`
 }
 
 type addDhcpCmd struct {
@@ -120,6 +121,10 @@ func setDhcp(infos []dhcpInfo) {
 			if info.DnsDomain != "" {
 				tree.Setf("service dhcp-server shared-network-name %s subnet %s static-mapping %s static-mapping-parameters \"%s\"",
 					netName, subnet, serverName, fmt.Sprintf("option domain-name &quot;%s&quot;;", info.DnsDomain))
+			}
+			if info.Mtu != 0 {
+				tree.Setf("service dhcp-server shared-network-name %s subnet %s static-mapping %s static-mapping-parameters \"%s\"",
+					netName, subnet, serverName, fmt.Sprintf("option interface-mtu %d;", info.Mtu))
 			}
 		}
 	}

--- a/src/zvr/plugin/dhcp_test.go
+++ b/src/zvr/plugin/dhcp_test.go
@@ -17,6 +17,7 @@ var infos = []dhcpInfo {
 		IsDefaultL3Network: true,
 		Hostname: "172-120-14-16",
 		Mac: "fa:da:21:1f:1a:11",
+		Mtu: 1500,
 	},
 
 	dhcpInfo{
@@ -29,6 +30,7 @@ var infos = []dhcpInfo {
 		IsDefaultL3Network: true,
 		Hostname: "172-120-14-17",
 		Mac: "fa:da:21:1f:1b:11",
+		Mtu: 1500,
 	},
 
 	// not existing one, for TestDHCPRemoveEntry
@@ -42,6 +44,7 @@ var infos = []dhcpInfo {
 		IsDefaultL3Network: true,
 		Hostname: "172-120-14-17",
 		Mac: "fa:63:21:1f:1b:11",
+		Mtu: 1500,
 	},
 }
 
@@ -83,6 +86,7 @@ service {
                     static-mapping-parameters "option domain-name-servers 8.8.8.8,114.114.114.114;"
                     static-mapping-parameters "option routers 172.20.14.114;"
                     static-mapping-parameters "option domain-name &quot;zstack.org&quot;;"
+                    static-mapping-parameters "option interface-mtu 1500;"
                 }
                 static-mapping fa_da_21_1f_1b_11 {
                     ip-address 172.20.14.17
@@ -92,6 +96,7 @@ service {
                     static-mapping-parameters "option domain-name-servers 8.8.8.8,114.114.114.114;"
                     static-mapping-parameters "option routers 172.20.14.114;"
                     static-mapping-parameters "option domain-name &quot;zstack.org&quot;;"
+                    static-mapping-parameters "option interface-mtu 1500;"
                 }
             }
         }
@@ -144,6 +149,7 @@ service {
                     static-mapping-parameters "option domain-name-servers 8.8.8.8,114.114.114.114;"
                     static-mapping-parameters "option routers 172.20.14.114;"
                     static-mapping-parameters "option domain-name &quot;zstack.org&quot;;"
+                    static-mapping-parameters "option interface-mtu 1500;"
                 }
                 static-mapping fa_da_21_1f_1b_11 {
                     ip-address 172.20.14.17
@@ -153,6 +159,7 @@ service {
                     static-mapping-parameters "option domain-name-servers 8.8.8.8,114.114.114.114;"
                     static-mapping-parameters "option routers 172.20.14.114;"
                     static-mapping-parameters "option domain-name &quot;zstack.org&quot;;"
+                    static-mapping-parameters "option interface-mtu 1500;"
                 }
             }
         }


### PR DESCRIPTION
Note: udhcpc which uesed in zstack BYO image and busybox don't
support this feature.
Ref: https://code.launchpad.net/~harmw/cirros/udhcpc-respect-mtu
https://launchpadlibrarian.net/180939577/udhcpc-respect-mtu.patch

This is the vyos driver.

For: zstackio/issues#3183