### PR TITLE
Fix for wrongly matching IPv6 address line problem in GetNicNameByIp

### DIFF
--- a/src/zvr/utils/net.go
+++ b/src/zvr/utils/net.go
@@ -119,8 +119,11 @@ func GetNicNameByMac(mac string) (string, error) {
 }
 
 func GetNicNameByIp(ip string) (string, error) {
+	// Modify IPv4 regex pattern from "a.b.c.d" to "a\.b\.c\.d" to avoid matching the line
+	// that contains IPv6 address, of which pattern is like 2001:db8::a:b:c:d
+	ipv4regex := strings.Replace(ip, ".", `\.`, -1)
 	bash := Bash{
-		Command: fmt.Sprintf("ip addr | grep -w %s", ip),
+		Command: fmt.Sprintf("ip addr | grep -w '%s'", ipv4regex),
 	}
 	ret, o, _, err := bash.RunWithReturn()
 	if err != nil {


### PR DESCRIPTION
Modify IPv4 regex pattern from `"a.b.c.d"` to `"a\.b\.c\.d"` to avoid matching the line that contains IPv6 address, of which pattern is like `2001:db8::a:b:c:d`

We have used ZStack to provide dual-stack access (support by ourselves) and encountered some subtle and magic problems.

If the vrouter use an IPv4 address like `A.B.C.D` and add an IPv6 address with IPv4-mixed-format like `2001:db8::A:B:C:D`, the GetNicNameByIp will return a non-existent interface named `"global"`, leading to trigger another error where this function is called.

The line that contains IPv6 address with style 2001:db8::A:B:C:D  will be matched by 'A.B.C.D' , because `grep` treats it as a regex by default. 

**`inet A.B.C.D/24 brd A.B.C.255 scope global (secondary) ethx`
`inet6 2001:db8::A:B:C:D/64 scope global`**

Meanwhile, IPv6 address line that outputed by `ip addr` do not end with `ethx` and `secondary`, so `return os[len(os)-1]` will return `global` as interface name and then ......
